### PR TITLE
Remove equals to fix API throwing error

### DIFF
--- a/MediaMathAPI.php
+++ b/MediaMathAPI.php
@@ -275,7 +275,7 @@ class MediaMathAPI {
 	    if ($this->parent && $filter['type'] != $this->parent) {
 		$filter_prefix = $this->getFilterPrefix($this->parent, $filter['type']);
 	    }
-	    $response = $this->call($this->method . '/limit/' . $filter_prefix . $filter['type'] . '=' . $filter['id'] . '?' . $args_str, Array());
+	    $response = $this->call($this->method . '/limit/' . $filter_prefix . $filter['type'] . $filter['id'] . '?' . $args_str, Array());
 	    if (!$filter['persist']) {
 		self::$_filter = Array();
 	    }


### PR DESCRIPTION
Removing the equals fixes the calls, which otherwise throw the following error:

<?xml version='1.0' ?>
<result>
    <error>Caught exception in Adama::Controller::Advertisers-&gt;collection_GET &quot;No relationship named '' in class Adama::DB::Object::Advertiser at /apps/t1/t1tmp/vFiXl_1rIg/Adama-v2.85.31/script/../lib/Adama/Base/Controller/EntityCRUD.pm line 527.&quot;</error>
    <status code="error">Caught exception in Adama::Controller::Advertisers-&gt;collection_GET &quot;No relationship named '' in class Adama::DB::Object::Advertiser at /apps/t1/t1tmp/vFiXl_1rIg/Adama-v2.85.31/script/../lib/Adama/Base/Controller/EntityCRUD.pm line 527.&quot;</status>
</result>